### PR TITLE
Adding criterion benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ members = [ "lcpc-2d", "lcpc-ligero-pc", "lcpc-brakedown-pc", "lcpc-test-fields"
 [workspace.dependencies]
 bincode = "1.3"
 bitvec = "1"
-blake3 = { version = "=1.2", features = ["traits-preview"] }
+blake3 = { version = "1.5", features = ["traits-preview"] }
 byteorder = "1"
 
-digest = "0.9"
+digest = "0.10"
 
 err-derive = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,40 @@
 [workspace]
 members = [ "lcpc-2d", "lcpc-ligero-pc", "lcpc-brakedown-pc", "lcpc-test-fields" ]
+
+[workspace.dependencies]
+bincode = "1.3"
+bitvec = "1"
+blake3 = { version = "1.2", features = ["traits-preview"] }
+byteorder = "1"
+
+digest = "0.9"
+
+err-derive = "0.2"
+
+ff = "0.12"
+ff-derive-num = "0.2"
+fffft = "0.4"
+
+itertools = "0.10"
+
+lcpc-2d = { path = "./lcpc-2d" }
+lcpc-test-fields = { path = "./lcpc-test-fields" }
+
+merlin = "2.0"
+
+ndarray = ">=0.11.0,<0.15"
+num-traits = "0.2"
+
+paste = "1.0"
+
+rand = "0.8"
+rand_chacha = "0.3"
+rand_core = "0.6"
+rayon = "1.5"
+
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
+sprs = "0.10"
+subtle = "2.2"
+
+typenum = "1.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [ "lcpc-2d", "lcpc-ligero-pc", "lcpc-brakedown-pc", "lcpc-test-fields"
 [workspace.dependencies]
 bincode = "1.3"
 bitvec = "1"
-blake3 = { version = "1.2", features = ["traits-preview"] }
+blake3 = { version = "=1.2", features = ["traits-preview"] }
 byteorder = "1"
 
 digest = "0.9"

--- a/lcpc-2d/Cargo.toml
+++ b/lcpc-2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcpc-2d"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["kwantam <kwantam@gmail.com>"]
 edition = "2018"
 description = "polynomial commitment scheme from linear codes"

--- a/lcpc-2d/Cargo.toml
+++ b/lcpc-2d/Cargo.toml
@@ -10,19 +10,19 @@ repository = "https://github.com/conroi/lcpc"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-digest = "0.9"
-err-derive = "0.2"
-ff = "0.12"
-merlin = "2.0"
-rand = "0.8"
-rand_chacha = "0.3"
-rayon = "1.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_bytes = "0.11"
+digest.workspace = true
+err-derive.workspace = true
+ff.workspace = true
+merlin.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
+rayon.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
 
 [dev-dependencies]
-bincode = "1.3"
-blake3 = { version = "1", features = ["traits-preview"] }
-fffft = "0.4"
-itertools = "0.10"
-lcpc-test-fields = { path = "../lcpc-test-fields" }
+bincode.workspace = true
+blake3.workspace = true
+fffft.workspace = true
+itertools.workspace = true
+lcpc-test-fields.workspace = true

--- a/lcpc-2d/src/lib.rs
+++ b/lcpc-2d/src/lib.rs
@@ -206,7 +206,11 @@ where
         D: Digest,
         E: LcEncoding<F = F>,
     {
-        let hashes = self.hashes.into_iter().map(|c| c.unwrap::<D, E>().root).collect();
+        let hashes = self
+            .hashes
+            .into_iter()
+            .map(|c| c.unwrap::<D, E>().root)
+            .collect();
 
         LcCommit {
             comm: self.comm,
@@ -226,7 +230,11 @@ where
     E::F: Serialize,
 {
     fn wrapped(&self) -> WrappedLcCommit<FldT<E>> {
-        let hashes_wrapped = self.hashes.iter().map(|h| WrappedOutput { bytes: h.to_vec() }).collect();
+        let hashes_wrapped = self
+            .hashes
+            .iter()
+            .map(|h| WrappedOutput { bytes: h.to_vec() })
+            .collect();
 
         WrappedLcCommit {
             comm: self.comm.clone(),
@@ -1092,6 +1100,7 @@ where
     })
 }
 
+#[allow(clippy::only_used_in_recursion)]
 fn collapse_columns<E>(
     coeffs: &[FldT<E>],
     tensor: &[FldT<E>],

--- a/lcpc-2d/src/lib.rs
+++ b/lcpc-2d/src/lib.rs
@@ -175,12 +175,18 @@ where
     D: Digest,
     E: LcEncoding,
 {
-    comm: Vec<FldT<E>>,
-    coeffs: Vec<FldT<E>>,
-    n_rows: usize,
-    n_cols: usize,
-    n_per_row: usize,
-    hashes: Vec<Output<D>>,
+    /// The encoded values
+    pub comm: Vec<FldT<E>>,
+    /// The coefficients pre-encoding
+    pub coeffs: Vec<FldT<E>>,
+    /// Number of rows in the commitment
+    pub n_rows: usize,
+    /// Number of columns in the commitment
+    pub n_cols: usize,
+    /// Number of pre-encoded values per row
+    pub n_per_row: usize,
+    /// Hashed values for Merkle commit
+    pub hashes: Vec<Output<D>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -326,7 +332,8 @@ where
     D: Digest,
     E: LcEncoding,
 {
-    root: Output<D>,
+    /// The Merkle root
+    pub root: Output<D>,
     _p: std::marker::PhantomData<E>,
 }
 
@@ -411,8 +418,10 @@ where
     D: Digest,
     E: LcEncoding,
 {
-    col: Vec<FldT<E>>,
-    path: Vec<Output<D>>,
+    /// The values in the column
+    pub col: Vec<FldT<E>>,
+    /// The Merkle path
+    pub path: Vec<Output<D>>,
 }
 
 impl<D, E> LcColumn<D, E>
@@ -501,10 +510,14 @@ where
     D: Digest,
     E: LcEncoding,
 {
-    n_cols: usize,
-    p_eval: Vec<FldT<E>>,
-    p_random_vec: Vec<Vec<FldT<E>>>,
-    columns: Vec<LcColumn<D, E>>,
+    /// Number of columns in this proof
+    pub n_cols: usize,
+    /// Evaluation row
+    pub p_eval: Vec<FldT<E>>,
+    /// Random combinations of rows
+    pub p_random_vec: Vec<Vec<FldT<E>>>,
+    /// Opened columns
+    pub columns: Vec<LcColumn<D, E>>,
 }
 
 impl<D, E> LcEvalProof<D, E>
@@ -557,7 +570,7 @@ where
 
 /// An evaluation and proof of its correctness and of the low-degreeness of the commitment.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct WrappedLcEvalProof<F>
+struct WrappedLcEvalProof<F>
 where
     F: Serialize,
 {

--- a/lcpc-2d/src/lib.rs
+++ b/lcpc-2d/src/lib.rs
@@ -633,7 +633,7 @@ where
 /// for a code with `len`-length codewords over `flog2`-bit field
 pub fn n_degree_tests(lambda: usize, len: usize, flog2: usize) -> usize {
     let den = flog2 - log2(len);
-    (lambda + den - 1) / den
+    lambda.div_ceil(den)
 }
 
 // parallelization limit when working on columns

--- a/lcpc-2d/src/lib.rs
+++ b/lcpc-2d/src/lib.rs
@@ -12,7 +12,7 @@
 lcpc2d is a polynomial commitment scheme based on linear codes
 */
 
-use digest::{Digest, Output};
+use digest::{Digest, FixedOutputReset, Output};
 use err_derive::Error;
 use ff::{Field, PrimeField};
 use merlin::Transcript;
@@ -277,7 +277,7 @@ where
 
 impl<D, E> LcCommit<D, E>
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
     E: LcEncoding,
 {
     /// returns the Merkle root of this polynomial commitment (which is the commitment itself)
@@ -509,7 +509,7 @@ where
 
 impl<D, E> LcEvalProof<D, E>
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
     E: LcEncoding,
 {
     /// Get the number of elements in an encoded vector
@@ -629,7 +629,7 @@ const LOG_MIN_NCOLS: usize = 5;
 /// Commit to a univariate polynomial whose coefficients are `coeffs` using encoding `enc`
 fn commit<D, E>(coeffs_in: &[FldT<E>], enc: &E) -> ProverResult<LcCommit<D, E>, ErrT<E>>
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
     E: LcEncoding,
 {
     let (n_rows, n_per_row, n_cols) = enc.get_dims(coeffs_in.len());
@@ -697,7 +697,7 @@ where
 
 fn merkleize<D, E>(comm: &mut LcCommit<D, E>)
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
     E: LcEncoding,
 {
     // step 1: hash each column of the commitment (we always reveal a full column)
@@ -754,7 +754,7 @@ fn hash_columns<D, E>(
 
 fn merkle_tree<D>(ins: &[Output<D>], outs: &mut [Output<D>])
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
 {
     // array should always be of length 2^k - 1
     assert_eq!(ins.len(), outs.len() + 1);
@@ -769,7 +769,7 @@ where
 
 fn merkle_layer<D>(ins: &[Output<D>], outs: &mut [Output<D>])
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
 {
     assert_eq!(ins.len(), 2 * outs.len());
 
@@ -777,8 +777,8 @@ where
         // base case: just compute all of the hashes
         let mut digest = D::new();
         for idx in 0..outs.len() {
-            digest.update(ins[2 * idx].as_ref());
-            digest.update(ins[2 * idx + 1].as_ref());
+            Digest::update(&mut digest, ins[2 * idx].as_ref());
+            Digest::update(&mut digest, ins[2 * idx + 1].as_ref());
             outs[idx] = digest.finalize_reset();
         }
     } else {
@@ -846,7 +846,7 @@ fn verify<D, E>(
     tr: &mut Transcript,
 ) -> VerifierResult<FldT<E>, ErrT<E>>
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
     E: LcEncoding,
 {
     // make sure arguments are well formed
@@ -962,11 +962,11 @@ where
 // Check a column opening
 fn verify_column_path<D, E>(column: &LcColumn<D, E>, col_num: usize, root: &Output<D>) -> bool
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
     E: LcEncoding,
 {
     let mut digest = D::new();
-    digest.update(<Output<D> as Default>::default());
+    Digest::update(&mut digest, <Output<D> as Default>::default());
     for e in &column.col[..] {
         e.digest_update(&mut digest);
     }
@@ -976,11 +976,11 @@ where
     let mut col = col_num;
     for p in &column.path[..] {
         if col % 2 == 0 {
-            digest.update(&hash);
-            digest.update(p);
+            Digest::update(&mut digest, &hash);
+            Digest::update(&mut digest, p);
         } else {
-            digest.update(p);
-            digest.update(&hash);
+            Digest::update(&mut digest, p);
+            Digest::update(&mut digest, &hash);
         }
         hash = digest.finalize_reset();
         col >>= 1;
@@ -1176,7 +1176,7 @@ fn verify_column<D, E>(
     poly_eval: &FldT<E>,
 ) -> bool
 where
-    D: Digest,
+    D: Digest + FixedOutputReset,
     E: LcEncoding,
 {
     verify_column_path(column, col_num, root) && verify_column_value(column, tensor, poly_eval)

--- a/lcpc-2d/src/tests.rs
+++ b/lcpc-2d/src/tests.rs
@@ -14,11 +14,11 @@ use digest::Output;
 use ff::Field;
 use fffft::{FFTError, FFTPrecomp, FieldFFT};
 use itertools::iterate;
+use lcpc_test_fields::ft63::*;
 use merlin::Transcript;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use std::iter::repeat_with;
-use lcpc_test_fields::ft63::*;
 
 #[derive(Clone, Debug)]
 struct LigeroEncoding<Ft> {
@@ -298,8 +298,7 @@ fn end_to_end() {
     )
     .unwrap();
 
-    let root2 =
-        bincode::deserialize::<LcRoot<Blake3, LigeroEncoding<Ft63>>>(&encroot[..]).unwrap();
+    let root2 = bincode::deserialize::<LcRoot<Blake3, LigeroEncoding<Ft63>>>(&encroot[..]).unwrap();
     let pf2: LigeroEvalProof<Blake3, Ft63> = bincode::deserialize(&encoded[..]).unwrap();
     let mut tr3 = Transcript::new(b"test transcript");
     tr3.append_message(b"polycommit", root.as_ref());

--- a/lcpc-2d/src/tests.rs
+++ b/lcpc-2d/src/tests.rs
@@ -49,7 +49,7 @@ where
 
         // minimize nr subject to #cols and rho
         let np = ((nc as f64) * rho).floor() as usize;
-        let nr = (len + np - 1) / np;
+        let nr = len.div_ceil(np);
         assert!(np * nr >= len);
         assert!(np * (nr - 1) < len);
 
@@ -99,7 +99,7 @@ where
     }
 
     fn get_dims(&self, len: usize) -> (usize, usize, usize) {
-        let n_rows = (len + self.n_per_row - 1) / self.n_per_row;
+        let n_rows = len.div_ceil(self.n_per_row);
         (n_rows, self.n_per_row, self.n_cols)
     }
 

--- a/lcpc-brakedown-pc/Cargo.toml
+++ b/lcpc-brakedown-pc/Cargo.toml
@@ -10,23 +10,23 @@ repository = "https://github.com/conroi/lcpc"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ff = "0.12"
-itertools = "0.10"
-lcpc-2d = { path = "../lcpc-2d", version = "0.1.1" }
-ndarray = ">=0.11.0,<0.15"
-num-traits = "0.2"
-rand = "0.8"
-rand_chacha = "0.3"
-rayon = "1.5"
-sprs = "0.10"
-typenum = "1.13"
+ff.workspace = true
+itertools.workspace = true
+lcpc-2d.workspace = true
+ndarray.workspace = true
+num-traits.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
+rayon.workspace = true
+sprs.workspace = true
+typenum.workspace = true
 
 [dev-dependencies]
-bincode = "1.3"
-blake3 = { version = "1.0", features = ["traits-preview"] }
-merlin = "2.0"
-paste = "1.0"
-lcpc-test-fields = { path = "../lcpc-test-fields", version = "0.1.1" }
+bincode.workspace = true
+blake3.workspace = true
+merlin.workspace = true
+paste.workspace = true
+lcpc-test-fields.workspace = true
 
 [features]
 bench = []

--- a/lcpc-brakedown-pc/Cargo.toml
+++ b/lcpc-brakedown-pc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcpc-brakedown-pc"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["kwantam <kwantam@gmail.com>"]
 edition = "2018"
 description = "polynomial commitment scheme from SDIG expander code"

--- a/lcpc-brakedown-pc/Cargo.toml
+++ b/lcpc-brakedown-pc/Cargo.toml
@@ -27,6 +27,12 @@ blake3.workspace = true
 merlin.workspace = true
 paste.workspace = true
 lcpc-test-fields.workspace = true
+criterion = { version = "0.5"  }
+sha2 = "0.10.8"
 
 [features]
 bench = []
+
+[[bench]]
+name = "encode"
+harness = false

--- a/lcpc-brakedown-pc/benches/encode.rs
+++ b/lcpc-brakedown-pc/benches/encode.rs
@@ -1,0 +1,172 @@
+// Criterion Benchmarks for encode, commit, prove, verify.
+// Use parameters that achieve distance 1/20 and rate 3/5.
+use blake3::Hasher as Blake3;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use ff::Field;
+use itertools::iterate;
+use lcpc_2d::LcEncoding;
+use lcpc_test_fields::{ft127::*, random_coeffs};
+use merlin::Transcript;
+use rand::thread_rng;
+use sha2::Sha256;
+use std::hint::black_box;
+
+use lcpc_brakedown_pc::{BrakedownCommit, SdigEncoding};
+
+fn encode_benchmark(c: &mut Criterion) {
+    use lcpc_brakedown_pc::codespec::SdigCode4 as TestCode;
+    let mut rng = thread_rng();
+    use lcpc_brakedown_pc::encode::{codeword_length, encode};
+    use lcpc_brakedown_pc::matgen::generate;
+
+    let mut group = c.benchmark_group("encode");
+
+    for lgl in [10, 12, 14, 16, 18, 20].iter() {
+        let (precodes, postcodes) = generate::<Ft127, TestCode>(1 << lgl, 0u64);
+        let xi_len = codeword_length(&precodes, &postcodes);
+        println!("lgl {} xi_len {}", lgl, xi_len);
+        let mut xi = Vec::with_capacity(xi_len);
+        for _ in 0..xi_len {
+            xi.push(Ft127::random(&mut rng));
+        }
+
+        group.bench_with_input(BenchmarkId::from_parameter(lgl), lgl, |b, &_size| {
+            b.iter(|| encode(&mut xi, &precodes, &postcodes));
+        });
+    }
+    group.finish();
+}
+
+fn commit_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("commit_127");
+
+    for lgl in [10usize, 12, 14, 16, 18].iter() {
+        let coeffs = random_coeffs(*lgl);
+        let enc = SdigEncoding::new(coeffs.len(), 0);
+
+        group.bench_with_input(BenchmarkId::new("blake_127", *lgl), lgl, |b, _lgl| {
+            b.iter(|| black_box(BrakedownCommit::<Blake3, Ft127>::commit(&coeffs, &enc).unwrap()));
+        });
+
+        group.bench_with_input(BenchmarkId::new("sha256_127", *lgl), lgl, |b, _lgl| {
+            b.iter(|| black_box(BrakedownCommit::<Sha256, Ft127>::commit(&coeffs, &enc).unwrap()));
+        });
+    }
+
+    group.finish();
+}
+
+fn matgen_benchmark(c: &mut Criterion) {
+    use lcpc_brakedown_pc::codespec::SdigCode4 as TestCode;
+    use lcpc_brakedown_pc::matgen::generate;
+    let mut group = c.benchmark_group("matgen");
+
+    for lgl in [16, 18, 20].iter() {
+        group.bench_with_input(BenchmarkId::from_parameter(lgl), lgl, |b, &_size| {
+            b.iter(|| generate::<Ft127, TestCode>(1 << lgl, 0u64));
+        });
+    }
+}
+
+fn prove_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prove");
+
+    for lgl in [14usize, 16, 18].iter() {
+        let coeffs = random_coeffs(*lgl);
+        let enc = SdigEncoding::new(coeffs.len(), 0);
+        let comm = BrakedownCommit::<Blake3, Ft127>::commit(&coeffs, &enc).unwrap();
+
+        // random point to eval at
+        let x = Ft127::random(&mut rand::thread_rng());
+        let inner_tensor: Vec<Ft127> = iterate(<Ft127 as Field>::one(), |&v| v * x)
+            .take(comm.get_n_per_row())
+            .collect();
+        let outer_tensor: Vec<Ft127> = {
+            let xr = x * inner_tensor.last().unwrap();
+            iterate(<Ft127 as Field>::one(), |&v| v * xr)
+                .take(comm.get_n_rows())
+                .collect()
+        };
+
+        group.bench_with_input(BenchmarkId::new("Blake3_127", *lgl), lgl, |b, _lgl| {
+            b.iter(|| {
+                let mut tr = Transcript::new(b"bench transcript");
+                tr.append_message(b"polycommit", comm.get_root().as_ref());
+                tr.append_message(b"rate", &0.25f64.to_be_bytes()[..]);
+                tr.append_message(b"ncols", &(enc.get_n_col_opens() as u64).to_be_bytes()[..]);
+                tr.append_message(
+                    b"ndegs",
+                    &(enc.get_n_degree_tests() as u64).to_be_bytes()[..],
+                );
+                black_box(comm.prove(&outer_tensor[..], &enc, &mut tr).unwrap());
+            });
+        });
+    }
+}
+
+fn verify_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("verify");
+
+    for lgl in [14usize, 16, 18].iter() {
+        let coeffs = random_coeffs(*lgl);
+        let enc = SdigEncoding::new(coeffs.len(), 0);
+        let comm = BrakedownCommit::<Blake3, Ft127>::commit(&coeffs, &enc).unwrap();
+
+        // random point to eval at
+        let x = Ft127::random(&mut rand::thread_rng());
+        let inner_tensor: Vec<Ft127> = iterate(<Ft127 as Field>::one(), |&v| v * x)
+            .take(comm.get_n_per_row())
+            .collect();
+        let outer_tensor: Vec<Ft127> = {
+            let xr = x * inner_tensor.last().unwrap();
+            iterate(<Ft127 as Field>::one(), |&v| v * xr)
+                .take(comm.get_n_rows())
+                .collect()
+        };
+
+        let mut tr = Transcript::new(b"bench transcript");
+        tr.append_message(b"polycommit", comm.get_root().as_ref());
+        tr.append_message(b"rate", &0.25f64.to_be_bytes()[..]);
+        tr.append_message(b"ncols", &(enc.get_n_col_opens() as u64).to_be_bytes()[..]);
+        tr.append_message(
+            b"ndegs",
+            &(enc.get_n_degree_tests() as u64).to_be_bytes()[..],
+        );
+        let pf = comm.prove(&outer_tensor[..], &enc, &mut tr).unwrap();
+        let root = comm.get_root();
+
+        group.bench_with_input(BenchmarkId::new("Blake3_127", *lgl), lgl, |b, _lgl| {
+            b.iter(|| {
+                let mut tr = Transcript::new(b"bench transcript");
+                tr.append_message(b"polycommit", comm.get_root().as_ref());
+                tr.append_message(b"rate", &0.25f64.to_be_bytes()[..]);
+                tr.append_message(b"ncols", &(enc.get_n_col_opens() as u64).to_be_bytes()[..]);
+                tr.append_message(
+                    b"ndegs",
+                    &(enc.get_n_degree_tests() as u64).to_be_bytes()[..],
+                );
+                black_box(
+                    pf.verify(
+                        root.as_ref(),
+                        &outer_tensor[..],
+                        &inner_tensor[..],
+                        &enc,
+                        &mut tr,
+                    )
+                    .unwrap(),
+                );
+            });
+        });
+    }
+}
+
+criterion_group!(
+    benches,
+    commit_benchmark,
+    encode_benchmark,
+    matgen_benchmark,
+    prove_benchmark,
+    verify_benchmark
+);
+
+criterion_main!(benches);

--- a/lcpc-brakedown-pc/src/bench.rs
+++ b/lcpc-brakedown-pc/src/bench.rs
@@ -9,15 +9,15 @@
 
 use super::{BrakedownCommit, SdigEncoding};
 
-use blake3::{Hasher as Blake3, traits::digest::Digest};
+use blake3::{traits::digest::Digest, Hasher as Blake3};
 use ff::{Field, PrimeField};
 use itertools::iterate;
 use lcpc_2d::{FieldHash, LcEncoding};
+use lcpc_test_fields::{def_bench, ft127::*, ft255::*, random_coeffs};
 use merlin::Transcript;
 use num_traits::Num;
 use sprs::MulAcc;
 use test::{black_box, Bencher};
-use lcpc_test_fields::{def_bench, ft127::*, ft255::*, random_coeffs};
 
 #[bench]
 fn matgen_bench(b: &mut Bencher) {

--- a/lcpc-brakedown-pc/src/encode.rs
+++ b/lcpc-brakedown-pc/src/encode.rs
@@ -14,8 +14,8 @@ use ndarray::{linalg::Dot, ArrayView};
 use num_traits::Num;
 use sprs::{CsMat, MulAcc};
 
-// given a set of precodes and postcodes, output length of codeword
-pub(super) fn codeword_length<F>(precodes: &[CsMat<F>], postcodes: &[CsMat<F>]) -> usize
+/// given a set of precodes and postcodes, output length of codeword
+pub fn codeword_length<F>(precodes: &[CsMat<F>], postcodes: &[CsMat<F>]) -> usize
 where
     F: Field + Num,
 {

--- a/lcpc-brakedown-pc/src/lib.rs
+++ b/lcpc-brakedown-pc/src/lib.rs
@@ -94,7 +94,7 @@ where
             n_cols,
             precodes,
             postcodes,
-            _p: std::marker::PhantomData::default(),
+            _p: std::marker::PhantomData,
         }
     }
 
@@ -132,7 +132,7 @@ where
             n_cols,
             precodes,
             postcodes,
-            _p: std::marker::PhantomData::default(),
+            _p: std::marker::PhantomData,
         }
     }
 }

--- a/lcpc-brakedown-pc/src/lib.rs
+++ b/lcpc-brakedown-pc/src/lib.rs
@@ -71,13 +71,13 @@ where
         let np1 = if np1 > len { len } else { np1 };
 
         let n_col_opens = Self::_n_col_opens();
-        let nr1 = (len + np1 - 1) / np1;
+        let nr1 = len.div_ceil(np1);
         let nd1 = Self::_n_degree_tests(np1 * 2); // approximately
         assert!(np1 * nr1 >= len);
         assert!(np1 * (nr1 - 1) < len);
 
         let np2 = np1 / 2;
-        let nr2 = (len + np2 - 1) / np2;
+        let nr2 = len.div_ceil(np2);
         let nd2 = Self::_n_degree_tests(np2 * 2); // approximately
         assert!(np2 * nr2 >= len);
         assert!(np2 * (nr2 - 1) < len);
@@ -153,7 +153,7 @@ where
     }
 
     fn get_dims(&self, len: usize) -> (usize, usize, usize) {
-        let n_rows = (len + self.n_per_row - 1) / self.n_per_row;
+        let n_rows = len.div_ceil(self.n_per_row);
         (n_rows, self.n_per_row, self.n_cols)
     }
 

--- a/lcpc-brakedown-pc/src/matgen.rs
+++ b/lcpc-brakedown-pc/src/matgen.rs
@@ -21,7 +21,7 @@ use rayon::prelude::*;
 use sprs::CsMat;
 
 const fn ceil_muldiv(n: usize, num: usize, den: usize) -> usize {
-    (n * num + den - 1) / den
+    (n * num).div_ceil(den)
 }
 
 /// Generate a random code from a given seed

--- a/lcpc-ligero-pc/Cargo.toml
+++ b/lcpc-ligero-pc/Cargo.toml
@@ -10,20 +10,20 @@ repository = "https://github.com/conroi/lcpc"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fffft = "0.4"
-lcpc-2d = { path = "../lcpc-2d", version = "0.1.1" }
-typenum = "1.13"
+fffft.workspace = true
+lcpc-2d.workspace = true
+typenum.workspace = true
 
 [dev-dependencies]
-bincode = "1.3"
-blake3 = { version = "1", features = ["traits-preview"] }
-ff = "0.12"
-itertools = "0.10"
-merlin = "2.0"
-paste = "1.0"
-rand = "0.8"
-rand_chacha = "0.3"
-lcpc-test-fields = { path = "../lcpc-test-fields", version = "0.1.1" }
+bincode.workspace = true
+blake3.workspace = true
+ff.workspace = true
+itertools.workspace = true
+merlin.workspace = true
+paste.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
+lcpc-test-fields.workspace = true
 
 [features]
 bench = []

--- a/lcpc-ligero-pc/Cargo.toml
+++ b/lcpc-ligero-pc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcpc-ligero-pc"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["kwantam <kwantam@gmail.com>"]
 edition = "2018"
 description = "polynomial commitment scheme from R-S codes, as in Ligero (CCS '17)"

--- a/lcpc-ligero-pc/src/bench.rs
+++ b/lcpc-ligero-pc/src/bench.rs
@@ -9,13 +9,13 @@
 
 use super::LigeroEncodingRho;
 
-use blake3::{Hasher as Blake3, traits::digest::Digest};
+use blake3::{traits::digest::Digest, Hasher as Blake3};
 use fffft::FieldFFT;
 use itertools::iterate;
 use lcpc_2d::{FieldHash, LcCommit, LcEncoding, SizedField};
+use lcpc_test_fields::{def_bench, ft127::*, ft255::*, random_coeffs};
 use merlin::Transcript;
 use test::{black_box, Bencher};
-use lcpc_test_fields::{def_bench, ft127::*, ft255::*, random_coeffs};
 use typenum::{Unsigned, U39 as TLo};
 
 type THi = <TLo as std::ops::Add<typenum::U1>>::Output;

--- a/lcpc-ligero-pc/src/lib.rs
+++ b/lcpc-ligero-pc/src/lib.rs
@@ -143,7 +143,7 @@ where
             n_per_row,
             n_cols,
             pc,
-            _p: std::marker::PhantomData::default(),
+            _p: std::marker::PhantomData,
         }
     }
 }

--- a/lcpc-ligero-pc/src/lib.rs
+++ b/lcpc-ligero-pc/src/lib.rs
@@ -85,7 +85,7 @@ where
 
         // minimize nr subject to #cols and RHO
         let np1 = nc1 * Self::_rho_num() / Self::_rho_den();
-        let nr1 = (len + np1 - 1) / np1;
+        let nr1 = len.div_ceil(np1);
         let nd1 = Self::_n_degree_tests(nc1);
         //assert!(np1.is_power_of_two());
         assert!(np1 * nr1 >= len);
@@ -93,7 +93,7 @@ where
 
         let nc2 = nc1 / 2;
         let np2 = np1 / 2;
-        let nr2 = (len + np2 - 1) / np2;
+        let nr2 = len.div_ceil(np2);
         let nd2 = Self::_n_degree_tests(nc2);
         //assert!(np2.is_power_of_two());
         assert!(nc2.is_power_of_two());
@@ -164,7 +164,7 @@ where
     }
 
     fn get_dims(&self, len: usize) -> (usize, usize, usize) {
-        let n_rows = (len + self.n_per_row - 1) / self.n_per_row;
+        let n_rows = len.div_ceil(self.n_per_row);
         (n_rows, self.n_per_row, self.n_cols)
     }
 

--- a/lcpc-ligero-pc/src/tests.rs
+++ b/lcpc-ligero-pc/src/tests.rs
@@ -13,11 +13,11 @@ use blake3::Hasher as Blake3;
 use ff::Field;
 use itertools::iterate;
 use lcpc_2d::{LcCommit, LcEncoding};
+use lcpc_test_fields::{ft255::*, ft63::*, random_coeffs};
 use merlin::Transcript;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use std::iter::repeat_with;
-use lcpc_test_fields::{ft255::*, ft63::*, random_coeffs};
 
 #[test]
 fn get_dims() {
@@ -56,16 +56,16 @@ fn col_opens() {
     );
 }
 
-#[cfg(feature="isz")]
-use typenum::U38 as TLo;
-#[cfg(not(feature="isz"))]
+#[cfg(not(feature = "isz"))]
 use typenum::U1 as TLo;
+#[cfg(feature = "isz")]
+use typenum::U38 as TLo;
 
-#[cfg(feature="isz")]
-use typenum::U39 as THi;
-#[cfg(all(not(feature="isz"), feature="hlf"))]
+#[cfg(all(not(feature = "isz"), feature = "hlf"))]
 use typenum::U2 as THi;
-#[cfg(all(not(feature="isz"),not(feature="hlf")))]
+#[cfg(feature = "isz")]
+use typenum::U39 as THi;
+#[cfg(all(not(feature = "isz"), not(feature = "hlf")))]
 use typenum::U4 as THi;
 
 #[test]

--- a/lcpc-test-fields/Cargo.toml
+++ b/lcpc-test-fields/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcpc-test-fields"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 authors = ["kwantam <kwantam@gmail.com>"]
 description = "fields for testing polycommits"

--- a/lcpc-test-fields/Cargo.toml
+++ b/lcpc-test-fields/Cargo.toml
@@ -10,12 +10,12 @@ repository = "https://github.com/conroi/lcpc"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitvec = "1"
-byteorder = "1"
-ff = { version = "0.12", features = ["derive"] }
-ff-derive-num = "0.2"
-num-traits = "0.2"
-rand = "0.8"
-rand_core = "0.6"
-serde = { version = "1.0", features = ["derive"] }
-subtle = "2.2"
+bitvec.workspace = true
+byteorder.workspace = true
+ff = { workspace = true, features = ["derive"] }
+ff-derive-num.workspace = true
+num-traits.workspace = true
+rand.workspace = true
+rand_core.workspace = true
+serde.workspace = true
+subtle.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "nightly"


### PR DESCRIPTION
"cargo bench" in the lcpc-brakedown-pc directory produces benchmark numbers for commit, encode, matgen, prove, verify.